### PR TITLE
Create optional CLI feature json_format

### DIFF
--- a/yake/Cargo.toml
+++ b/yake/Cargo.toml
@@ -6,4 +6,8 @@ edition = "2021"
 [dependencies]
 yake-rust = { path = "../yake_rust" }
 clap = { version = "4.5.26", features = ["cargo", "derive", "string"] }
-serde_json = "1.0.135"
+serde_json = { version = "1.0.135", optional = true}
+
+[features]
+default = ["json_format"]
+json_format = ["dep:serde_json"]

--- a/yake/Cargo.toml
+++ b/yake/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 yake-rust = { path = "../yake_rust" }
 clap = { version = "4.5.26", features = ["cargo", "derive", "string"] }
-serde_json = { version = "1.0.135", optional = true}
+serde_json = { version = "1.0.135", optional = true }
 
 [features]
 default = ["json_format"]
-json_format = ["dep:serde_json"]
+json_format = ["dep:serde_json", "yake-rust/serialize"]

--- a/yake/src/cli.rs
+++ b/yake/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser};
 use std::{path::PathBuf, sync::LazyLock};
 
+use clap::error::ErrorKind;
 use clap::{command, Args};
+use clap::{CommandFactory, Parser};
 use yake_rust::{Config, StopWords};
 
 static DEFAULT_CONFIG: LazyLock<Config> = LazyLock::new(Config::default);
@@ -68,9 +68,11 @@ struct Cli {
 
     // -l, --language TEXT
     /// Language
-    #[arg(short, long, default_value= "en", value_parser = parse_language, help = "Language", value_name = "TEXT")]
+    #[arg(short, long, default_value= "en", value_parser = parse_language, help = "Language", value_name = "TEXT"
+    )]
     language: StopWords,
 
+    #[cfg(feature = "json_format")]
     #[arg(long, help = "Dump output as JSON")]
     json: bool,
 }
@@ -92,6 +94,7 @@ pub struct ParsedCli {
     pub config: Config,
     pub language: StopWords,
     pub input: String,
+    #[cfg(feature = "json_format")]
     pub json: bool,
     pub top: Option<usize>,
     pub verbose: bool,
@@ -127,6 +130,7 @@ pub fn parse_cli() -> ParsedCli {
         },
         language: cli.language,
         input,
+        #[cfg(feature = "json_format")]
         json: cli.json,
         verbose: cli.verbose,
         top: cli.top,

--- a/yake/src/main.rs
+++ b/yake/src/main.rs
@@ -4,18 +4,31 @@ use yake_rust::{ResultItem, Yake};
 mod cli;
 
 fn main() {
-    let ParsedCli { language, json, input, config, top, verbose: _ } = parse_cli();
+    let ParsedCli {
+        language,
+        #[cfg(feature = "json_format")]
+        json,
+        input,
+        config,
+        top,
+        verbose: _,
+    } = parse_cli();
 
     let now = std::time::Instant::now();
 
     let keywords = Yake::new(language, config).get_n_best(&input, top);
 
-    output_keywords(&keywords, json);
+    output_keywords(
+        &keywords,
+        #[cfg(feature = "json_format")]
+        json,
+    );
 
     eprintln!("Elapsed: {:.2?}", now.elapsed());
 }
 
-fn output_keywords(keywords: &[ResultItem], json: bool) {
+fn output_keywords(keywords: &[ResultItem], #[cfg(feature = "json_format")] json: bool) {
+    #[cfg(feature = "json_format")]
     if json {
         match serde_json::to_string(&keywords) {
             Ok(str) => {
@@ -25,7 +38,7 @@ fn output_keywords(keywords: &[ResultItem], json: bool) {
                 eprintln!("Unexpected error happened while trying to serialize result to json : {:?}", e)
             }
         }
-    } else {
-        println!("{:?}", keywords);
+        return;
     }
+    println!("{:?}", keywords);
 }

--- a/yake_rust/Cargo.toml
+++ b/yake_rust/Cargo.toml
@@ -82,6 +82,7 @@ sv = []
 tr = []
 uk = []
 zh = []
+serialize = ["dep:serde"]
 
 [dependencies]
 regex = "1"
@@ -90,7 +91,7 @@ contractions = "0.5.4"
 segtok = "0.1.0"
 levenshtein = "1.0.5"
 indexmap = "2.7.0"
-serde = "1.0.217"
+serde = { version = "1.0.217", optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use indexmap::{IndexMap, IndexSet};
 use preprocessor::{split_into_sentences, split_into_words};
+#[cfg(feature = "serialize")]
 use serde::Serialize;
 use stats::{mean, median, stddev};
 
@@ -101,7 +102,8 @@ struct YakeCandidate {
     weight: f64,
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize)]
+#[derive(PartialEq, Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct ResultItem {
     pub raw: String,
     pub keyword: LString,


### PR DESCRIPTION
Add features `json_format` to yake cli, Enabled by default although I don't know if it's a good pratice. I also don't know if putting lot of `#[cfg(feature = "json_format")]` in code is a good pratice, altering signatures and structures
