### PR TITLE
Set serde optional for yake_rust

### DIFF
--- a/yake/Cargo.toml
+++ b/yake/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-yake-rust = { path = "../yake_rust" }
+yake-rust = { path = "../yake_rust" , features = ["serde"]}
 clap = { version = "4.5.26", features = ["cargo", "derive", "string"] }
 serde_json = "1.0.135"

--- a/yake/src/cli.rs
+++ b/yake/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser};
 use std::{path::PathBuf, sync::LazyLock};
 
+use clap::error::ErrorKind;
 use clap::{command, Args};
+use clap::{CommandFactory, Parser};
 use yake_rust::{Config, StopWords};
 
 static DEFAULT_CONFIG: LazyLock<Config> = LazyLock::new(Config::default);

--- a/yake_rust/Cargo.toml
+++ b/yake_rust/Cargo.toml
@@ -90,7 +90,7 @@ contractions = "0.5.4"
 segtok = "0.1.0"
 levenshtein = "1.0.5"
 indexmap = "2.7.0"
-serde = "1.0.217"
+serde = { version = "1.0.217", optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -103,7 +103,7 @@ struct YakeCandidate {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct ResultItem {
     pub raw: String,
     pub keyword: LString,

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use indexmap::{IndexMap, IndexSet};
 use preprocessor::{split_into_sentences, split_into_words};
 #[cfg(feature = "serde")]
-use serde::Serialize;
+use serde;
 use stats::{mean, median, stddev};
 
 use crate::levenshtein::levenshtein_ratio;
@@ -103,7 +103,7 @@ struct YakeCandidate {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResultItem {
     pub raw: String,
     pub keyword: LString,
@@ -129,6 +129,7 @@ struct PreCandidate<'s> {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config {
     /// The number of n-grams.
     ///
@@ -163,6 +164,7 @@ impl Default for Config {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Yake {
     config: Config,
     stop_words: StopWords,

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use indexmap::{IndexMap, IndexSet};
 use preprocessor::{split_into_sentences, split_into_words};
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use stats::{mean, median, stddev};
 
@@ -101,7 +102,8 @@ struct YakeCandidate {
     weight: f64,
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize)]
+#[derive(PartialEq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ResultItem {
     pub raw: String,
     pub keyword: LString,

--- a/yake_rust/src/stopwords/mod.rs
+++ b/yake_rust/src/stopwords/mod.rs
@@ -7,6 +7,7 @@ use crate::LString;
 /// The list is used to mark potentially meaningless tokens and generally based on the language
 /// given as input. Tokens with fewer than three characters are also considered a stopword.
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StopWords {
     set: HashSet<LString>,
 }


### PR DESCRIPTION
A much simpler version of https://github.com/kristof-mattei/yake-rust/pull/2 without cli feature and using implicit `serde` feature.

We should define whether or not Serialize and Deserialize should be implemented for all pub struct of yake_rust